### PR TITLE
add sdl as a dependency in build.zig.zon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/deps/sdl"]
-	path = src/deps/sdl
-	url = https://www.github.com/jack-ji/sdl.zig

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const sdl = @import("src/deps/sdl/build.zig");
+const sdl = @import("sdl");
 const imgui = @import("src/deps/imgui/build.zig");
 const zaudio = @import("src/deps/zaudio/build.zig");
 const stb = @import("src/deps/stb/build.zig");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,5 +10,9 @@
     },
     .dependencies = .{
         .system_sdk = .{ .path = "src/deps/system-sdk" },
+        .sdl = .{
+            .url = "https://github.com/Jack-Ji/SDL.zig/archive/d501c92a1a339ed20bfde98a54f3f72a3627915e.tar.gz",
+            .hash = "122067acb4438715380b8573444b351f5c028272e8ad5aa96ce4f059ab464a3bbea2",
+        },
     },
 }


### PR DESCRIPTION
this adds sdl as a dependency in build.zig.zon instead of having submodules