### PR TITLE
Remove explicit dependency naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ TIPS: To eliminate console terminal on Windows platform, override `exe.subsystem
 
    Add jok dependency to your build.zig.zon, with following command:
     ```bash
-    zig fetch --save=jok git+https://github.com/jack-ji/jok.git
+    zig fetch --save git+https://github.com/jack-ji/jok.git
     ```
 
 2. Use *jok*'s build script to add build step


### PR DESCRIPTION
Since `build.zig.zon` already specifies the dependency name to be `jok`, it's unneccessary to explicitly name the dependency:

https://github.com/Jack-Ji/jok/blob/8c738b0baf01c61080220abd661064106b3b8000/build.zig.zon#L2