### PR TITLE
fix(tileset): load image data relative to the tileset path

### DIFF
--- a/src/utils/tiled.zig
+++ b/src/utils/tiled.zig
@@ -649,21 +649,30 @@ fn loadTilesets(
                     continue;
                 }
                 if (std.mem.eql(u8, a.name, "source")) {
-                    // Store the directory that the current tileset is operating in
-                    // NOTE: physfs will *not* resolve paths containing '..', so the user will have to either:
-                    //   a) Disable it and reference full relative paths (which will expand these paths during opening)
-                    //   b) Put the data in a subdirectory
-                    //   c) Keep all of the data files in the same directory as the TMX file
+                    // If the tileset is in a different directory, slice it and save it
                     tileset_dir = if (std.mem.lastIndexOfScalar(u8, a.value, '/')) |idx|
                         a.value[0..idx]
                     else
                         "";
 
+                    // Resolve our directory & source into a path. If we're using physfs, default to POSIX so as to use '/'
+                    const full_path = if (use_physfs)
+                        try std.fs.path.resolvePosix(temp_allocator, &.{ dirname, a.value })
+                    else
+                        try std.fs.path.resolve(temp_allocator, &.{ dirname, a.value });
+                    defer temp_allocator.free(full_path);
+
+                    // Slice our path into a directory and a file name
+                    const full_dirname, const file_name = if (std.mem.lastIndexOfScalar(u8, full_path, '/')) |idx|
+                        .{ full_path[0..idx], full_path[idx..] }
+                    else
+                        return error.FailedPathResolution;
+
                     const tsx_content = try getExternalFileContent(
                         temp_allocator,
                         use_physfs,
-                        dirname,
-                        a.value,
+                        full_dirname,
+                        file_name,
                     );
                     defer temp_allocator.free(tsx_content);
 
@@ -723,15 +732,24 @@ fn loadTilesets(
             for (img.attributes) |a| {
                 if (std.mem.eql(u8, a.name, "source")) {
                     // Fetch the source relative to our tilemap by joining the current directory with our tileset directory
-                    const sep = if (use_physfs) "/" else std.fs.path.sep_str;
-                    const full_dirname = try std.mem.joinZ(temp_allocator, sep, &.{ dirname, tileset_dir });
-                    defer temp_allocator.free(full_dirname);
+                    // Like above, we will resolve to POSIX if we're using physfs. Otherwise, we'll default back to the system
+                    const full_path = if (use_physfs)
+                        try std.fs.path.resolvePosix(temp_allocator, &.{ dirname, tileset_dir, a.value })
+                    else
+                        try std.fs.path.resolve(temp_allocator, &.{ dirname, tileset_dir, a.value });
+                    defer temp_allocator.free(full_path);
+
+                    // Similarly to our tileset directory resolution, we split this into its directory name and file name
+                    const full_dirname, const file_name = if (std.mem.lastIndexOfScalar(u8, full_path, '/')) |idx|
+                        .{ full_path[0..idx], full_path[idx..] }
+                    else
+                        return error.FailedPathResolution;
 
                     const image_content = try getExternalFileContent(
                         temp_allocator,
                         use_physfs,
                         full_dirname,
-                        a.value,
+                        file_name,
                     );
                     defer temp_allocator.free(image_content);
                     ts[tsidx].texture = try rd.createTextureFromFileData(image_content, .static, false);


### PR DESCRIPTION
## Overview
In its current form, the TMX loader does not respect relative paths for tilesets/images. This commit remedies that issue by loading images with respect to the tileset's referenced directory.

## Testing
I've done a small amount of testing with both physfs on & off and through the tile data being in a parent directory, sub-directory, and same directory as the tilemap file. As far as I could see, there were not any major issues until testing with physfs on & in a parent directory.

Given that physfs won't automatically expand these paths, any attempt to utilize '..' in a tileset's image path will result in a `error.BadFilename` error. I've noted this & the potential remedies for users. If necessary, I can remove this note and/or attempt to fix this issue but that would require some extra allocation and path resolution.