### PR TITLE
fix(tiled): ensure we handle CRLF sequences when loading tilemaps

### DIFF
--- a/src/utils/tiled.zig
+++ b/src/utils/tiled.zig
@@ -982,7 +982,7 @@ fn loadLayers(
                         .gids = &.{},
                     });
                     var gids = try std.ArrayList(GlobalTileID).initCapacity(arena_allocator, 20);
-                    var gid_it = std.mem.splitAny(u8, data.children[0].char_data, ",\n");
+                    var gid_it = std.mem.splitAny(u8, data.children[0].char_data, ",\r\n");
                     while (gid_it.next()) |s| {
                         if (s.len == 0) continue;
                         try gids.append(.{ ._id = try std.fmt.parseInt(u32, s, 10) });


### PR DESCRIPTION
## Overview
When developing my game, I noticed that I was receiving errors regarding invalid characters. Upon a closer look, I realized that Jok does not handle CRLF sequences for these tilemaps. Given that I use Windows, Tiled automatically exports these maps using CRLF sequences for new lines. This PR aims to resolve that by adding `\r` as a supported separator in the `loadLayers` function.

## Testing
Upon testing in my codebase, this quickly resolved the issue. There should be no ill-advised effects from this as an extra split in our iterator will just result in the `continue` statement being executed.